### PR TITLE
GitHub Workflow support for setup.py 

### DIFF
--- a/.github/workflows/dlint-setup_py.yml
+++ b/.github/workflows/dlint-setup_py.yml
@@ -4,7 +4,7 @@ jobs:
   security_checks:
     # runs-on: ubuntu-latest
     runs-on: ubuntu-20.04
-    name: Execute the Duo Dlint action
+    name: Execute the Duo Dlint action against setup.py
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
@@ -15,7 +15,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         cd ./Python
-        python3 setup.py install
+        test -f ./setup.py && python3 setup.py install
         pip3 freeze > requirements.txt
         pip3 install dlint
         python3 -m flake8 --select=DUO ./Python

--- a/.github/workflows/pyup-safety-setup_py.yml
+++ b/.github/workflows/pyup-safety-setup_py.yml
@@ -13,6 +13,7 @@ jobs:
     # runs-on: ubuntu-latest
     runs-on: ubuntu-20.04
 
+    name: Run safety from PyUp against setup.py
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.10.0
@@ -23,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         cd ./Python
-        python3 setup.py install
+        test -f ./setup.py && python3 setup.py install
         pip3 freeze > requirements.txt
         pip3 install safety
         safety check -r requirements.txt


### PR DESCRIPTION
To replace `distutils` with `setuptools` I'll need to migrate their GitHub Workflows first.

Once this PR is accepted I'll resubmit the final PR to complete the migration to `setuptools` as agreed within Issue https://github.com/IntelligenceX/SDK/issues/23#issuecomment-1188154146.


