### PR TITLE
Added Group and IndexFile fields to SearchResult struct

### DIFF
--- a/Go/ixapi/API.go
+++ b/Go/ixapi/API.go
@@ -124,6 +124,8 @@ type SearchResult struct {
 	TagsH        []PanelSearchResultTag `json:"tagsh"`        // Human friendly tags
 	RandomID     uuid.UUID              `json:"randomid"`     // Random ID
 	BucketH      string                 `json:"bucketh"`      // Human friendly bucket name
+	Group        string                 `json:"group"`        // File Group
+	IndexFile    string                 `json:"indexfile"`    // Index file ID
 }
 
 // IntelligentSearchResult contains the result items


### PR DESCRIPTION
Added Group and IndexFile fields to SearchResult struct, these fields are returned for /intelligent/search searches, yet in the old binding were not part of the result structure, causing these values to just be lost when parsing the result.