### PR TITLE
Solve Issue #561. error: [Errno 2] No such file or directory: 'script…

### DIFF
--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -29,4 +29,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 package-dir = {"" = "intelx"}
-script-files = ["scripts/intelx.py"]
+script-files = ["cli/intelx.py"]


### PR DESCRIPTION
When you try to install the python SDK by following these steps:

    git clone https://github.com/intelligencex/sdk
    cd sdk/Python
    pip3 install -r requirements.txt
    pip3 install .

You get the following error:
#0 46.86 Building wheels for collected packages: intelx
#0 46.86   Building wheel for intelx (pyproject.toml): started
#0 47.93   Building wheel for intelx (pyproject.toml): finished with status 'error'
#0 47.96   error: subprocess-exited-with-error
#0 47.96
#0 47.96   × Building wheel for intelx (pyproject.toml) did not run successfully.
#0 47.96   │ exit code: 1
#0 47.96   ╰─> [17 lines of output]
#0 47.96       running bdist_wheel
#0 47.96       running build
#0 47.96       running build_py
#0 47.96       creating build
#0 47.96       creating build/lib
#0 47.96       copying intelx/intelxapi.py -> build/lib
#0 47.96       copying intelx/intelx_identity.py -> build/lib
#0 47.96       running egg_info
#0 47.96       writing intelx/intelx.egg-info/PKG-INFO
#0 47.96       writing dependency_links to intelx/intelx.egg-info/dependency_links.txt
#0 47.96       writing requirements to intelx/intelx.egg-info/requires.txt
#0 47.96       writing top-level names to intelx/intelx.egg-info/top_level.txt
#0 47.96       reading manifest file 'intelx/intelx.egg-info/SOURCES.txt'
#0 47.96       writing manifest file 'intelx/intelx.egg-info/SOURCES.txt'
#0 47.96       running build_scripts
#0 47.96       creating build/scripts-3.8
#0 47.96       error: [Errno 2] No such file or directory: 'scripts/intelx.py'
#0 47.96       [end of output]
#0 47.96
#0 47.96   note: This error originates from a subprocess, and is likely not a problem with pip.
#0 47.97   ERROR: Failed building wheel for intelx

This is solved by modifying the pyproject.toml file updating the reference to the correct path cli/intelx.py