### PR TITLE
Add missing dependency to requirements.txt

### DIFF
--- a/Maltego Transform/requirements.txt
+++ b/Maltego Transform/requirements.txt
@@ -1,1 +1,2 @@
 maltego-trx
+intelx


### PR DESCRIPTION
Added `intelx` to `requirements.txt` to resolve a missing dependency issue.
