### PR TITLE
Add idsearch terminated records none verification

### DIFF
--- a/Python/intelx/intelx_identity.py
+++ b/Python/intelx/intelx_identity.py
@@ -44,8 +44,9 @@ class IdentityService(intelx):
                     results.append(a)
                 maxresults -= len(r['records'])
             if (r['status'] == 2 or maxresults <= 0):
-                for a in r['records']:
-                    results.append(a)
+                if r['records']:
+                    for a in r['records']:
+                        results.append(a)
                 if (maxresults <= 0):
                     self.terminate_search(search_id)
                 done = True


### PR DESCRIPTION
Sometimes the status code from result is terminated and the records is none, it throws the following error:

```bash
intelx_identity.py, line 58, in idsearch
    for a in r['records']:
TypeError: 'NoneType' object is not iterable
```

This problem is similar to the reported in the PR https://github.com/IntelligenceX/SDK/pull/581